### PR TITLE
Add appdata

### DIFF
--- a/com.play0ad.zeroad.appdata.xml
+++ b/com.play0ad.zeroad.appdata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">com.play0ad.zeroad</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <name>0 A.D.</name>
+  <summary>Real-Time Strategy Game of Ancient Warfare</summary>
+  <description>
+    <p>
+      0 A.D. is a real-time strategy (RTS) game of ancient warfare.
+      It's a historically-based war and economy game that allows players to relive or rewrite the history of thirteen ancient civilizations, each depicted at their peak of economic growth and military prowess.
+    </p>
+    <p>
+      The thirteen factions are: Three of the Hellenic States (Athens, Sparta and Macedonia), two of the kingdoms of Alexander the Great's successors (Seleucids and Ptolemaic Egyptians), two Celtic tribes (Britons and Gauls), the Romans, the Persians, the Iberians, the Carthaginians, the Mauryas and the Kushites.
+    Each civilization is complete with substantially unique artwork, technologies and civilization bonuses.
+    </p>
+  </description>
+  <url type="homepage">https://play0ad.com</url>
+  <screenshots>
+    <screenshot type="default">https://play0ad.com/wp-content/gallery/screenshots/EgyptianPyramids.jpg</screenshot>
+    <screenshot>https://play0ad.com/wp-content/gallery/screenshots/Kushcitycenter.jpg</screenshot>
+    <screenshot>https://play0ad.com/wp-content/gallery/screenshots/water-specular.jpg</screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+  </content_rating>
+  <releases>
+    <release version="Alpha 25b" date="2021-08-26"/>
+  </releases>
+</application>


### PR DESCRIPTION
I noticed on GNOME Software that the license for 0 A.D. is incorrect.

![0ad-license](https://user-images.githubusercontent.com/2211671/170950128-44685938-9cf5-4826-b284-9f3725eb66ee.jpg)

I believe adding Appdata XML may fix this issue. 
I could be wrong, but probably Appdata isn't a bad thing to have.