### PR TITLE
SDL_VIDEODRIVER safeguard for Wayland use

### DIFF
--- a/com.play0ad.zeroad.yaml
+++ b/com.play0ad.zeroad.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
+  - --env=SDL_VIDEODRIVER=x11
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
This sets the `SDL_VIDEODRIVER` environment variable to `x11`, solving the issue in #53.