### PR TITLE
chore: update runtime to v24.08

### DIFF
--- a/com.play0ad.zeroad.yaml
+++ b/com.play0ad.zeroad.yaml
@@ -1,6 +1,6 @@
 app-id: com.play0ad.zeroad
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions: [org.freedesktop.Sdk.Extension.rust-stable]
 command: 0ad

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
And disable `automerge-flathubbot-prs`, cf. https://docs.flathub.org/blog/linter-restricting-automatic-merge.