### PR TITLE
chore: disable `automerge-flathubbot-prs`

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
cf. https://docs.flathub.org/blog/linter-restricting-automatic-merge